### PR TITLE
Upgrade version of mjml

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-download-stream": "0.0.13",
     "gulp-ext-replace": "^0.3.0",
     "gulp-html-i18n": "^0.6.1",
-    "gulp-mjml": "2.0.0",
+    "gulp-mjml": "^2.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-replace-task": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-download-stream": "0.0.13",
     "gulp-ext-replace": "^0.3.0",
     "gulp-html-i18n": "^0.6.1",
-    "gulp-mjml": "^1.0.1",
+    "gulp-mjml": "2.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-replace-task": "^0.11.0",


### PR DESCRIPTION
Due to a bug with the 1.0.1 version gulp-mjml (cf. https://github.com/mjmlio/gulp-mjml/issues/11) we need to upgrade to version 2
